### PR TITLE
:scroll: Add support for PDF and DOCX

### DIFF
--- a/files_to_claude_xml.py
+++ b/files_to_claude_xml.py
@@ -9,6 +9,7 @@
 # ///
 import mimetypes
 from pathlib import Path
+from typing import Annotated
 
 import typer
 from rich import print

--- a/files_to_claude_xml.py
+++ b/files_to_claude_xml.py
@@ -3,6 +3,7 @@
 # dependencies = [
 #     "rich",
 #     "typer",
+#     "python-docx",
 # ]
 # ///
 
@@ -11,7 +12,14 @@ from typing import Annotated
 
 import typer
 from rich import print
+from docx import Document
 
+def is_docx(file_path: Path) -> bool:
+    return file_path.suffix.lower() == '.docx'
+
+def read_docx_content(file_path: Path) -> str:
+    doc = Document(file_path)
+    return '\n'.join([paragraph.text for paragraph in doc.paragraphs])
 __version__ = "2024.10.4"
 
 
@@ -26,7 +34,10 @@ def compile_xml(*, files: list[Path], verbose: bool = False) -> str:
             print(file.as_posix())
 
         try:
-            content = file.read_text()
+            if is_docx(file):
+                content = read_docx_content(file)
+            else:
+                content = file.read_text()
             xml_parts.append(f'<document index="{index}">')
             xml_parts.append(f"<source>{file.as_posix()}</source>")
             xml_parts.append("<document_content>")

--- a/files_to_claude_xml.py
+++ b/files_to_claude_xml.py
@@ -7,7 +7,7 @@
 #     "pdfminer.six",
 # ]
 # ///
-
+import mimetypes
 from pathlib import Path
 
 import typer
@@ -42,15 +42,19 @@ def read_pdf_content(file_path: Path) -> str:
 
 def read_file_content(file_path: Path) -> str:
     try:
-        match file_path.suffix.lower():
-            case '.docx':
+        mime_type, _ = mimetypes.guess_type(file_path)
+        match mime_type:
+            case 'application/vnd.openxmlformats-officedocument.wordprocessingml.document':
                 return read_docx_content(file_path)
-            case '.pdf':
+            case 'application/pdf':
                 return read_pdf_content(file_path)
+            case 'text/plain':
+                return read_text_file(file_path)
             case _:
                 return read_text_file(file_path)
     except Exception as e:
         raise ValueError(f"Error reading file {file_path}: {str(e)}")
+
 
 
 def compile_xml(*, files: list[Path], verbose: bool = False) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ authors = [
     {name = "Jeff Triplett"}
 ]
 license = "PolyForm-Noncommercial-1.0.0"
-license-files = ["LICENSE"]
 
 [project.urls]
 Homepage = "https://github.com/jefftriplett/files-to-claude-xml"


### PR DESCRIPTION
Resolve #1 

This pull request introduces significant enhancements to the `files_to_claude_xml.py` script, focusing on improving file type handling and content extraction. The main changes include adding support for reading DOCX and PDF files, and refactoring the file content reading logic.

### Enhancements to file type handling and content extraction:

* Added dependencies for `python-docx` and `pdfminer.six` to handle DOCX and PDF files, respectively. (`files_to_claude_xml.py`)
* Implemented `read_docx_content`, `read_pdf_content`, and `read_text_file` functions to extract content from DOCX, PDF, and text files. (`files_to_claude_xml.py`)
* Created a `read_file_content` function that uses MIME type detection to delegate file reading to the appropriate function. (`files_to_claude_xml.py`)

### Refactoring for better error handling and verbosity:

* Updated the `compile_xml` function to use `read_file_content` for reading file content and added verbose logging for successful processing. (`files_to_claude_xml.py`)